### PR TITLE
Add Supabase JWT verification and authenticated route tests

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package marker for test imports."""

--- a/backend/app/jwt_fallback.py
+++ b/backend/app/jwt_fallback.py
@@ -1,0 +1,127 @@
+"""Minimal HS256 JWT implementation used when PyJWT is unavailable.
+
+This module only implements the subset of functionality required by the
+application tests: HS256 signing/verification, expiration (`exp`), issuer
+(`iss`), and audience (`aud`) validation. It exposes a compatible surface with
+the parts of PyJWT used by the FastAPI app so that production deployments can
+still rely on the real dependency while local, offline test runs continue to
+work.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import hmac
+import hashlib
+from typing import Any, Dict, Iterable, Optional
+
+
+class InvalidTokenError(Exception):
+    """Raised when a token fails general validation checks."""
+
+
+class ExpiredSignatureError(InvalidTokenError):
+    """Raised when the token has expired."""
+
+
+class InvalidAudienceError(InvalidTokenError):
+    """Raised when the token audience does not match expectations."""
+
+
+class InvalidIssuerError(InvalidTokenError):
+    """Raised when the token issuer does not match expectations."""
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(segment: str) -> bytes:
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+
+def _sign(message: bytes, secret: str) -> bytes:
+    return hmac.new(secret.encode("utf-8"), message, hashlib.sha256).digest()
+
+
+def encode(payload: Dict[str, Any], secret: str, algorithm: str = "HS256") -> str:
+    if algorithm != "HS256":
+        raise InvalidTokenError(f"Unsupported algorithm: {algorithm}")
+
+    header = {"alg": algorithm, "typ": "JWT"}
+    segments = [
+        _b64url_encode(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8")),
+        _b64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")),
+    ]
+
+    signing_input = ".".join(segments).encode("utf-8")
+    signature = _b64url_encode(_sign(signing_input, secret))
+    segments.append(signature)
+    return ".".join(segments)
+
+
+def decode(
+    token: str,
+    secret: str,
+    algorithms: Optional[Iterable[str]] = None,
+    audience: Optional[str | Iterable[str]] = None,
+    issuer: Optional[str] = None,
+    options: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    algorithms = set(algorithms or [])
+    if algorithms and "HS256" not in algorithms:
+        raise InvalidTokenError("Unsupported algorithm")
+
+    try:
+        header_segment, payload_segment, signature_segment = token.split(".")
+    except ValueError as exc:
+        raise InvalidTokenError("Not enough segments") from exc
+
+    header = json.loads(_b64url_decode(header_segment))
+    if header.get("alg") != "HS256":
+        raise InvalidTokenError("Invalid algorithm")
+
+    signing_input = f"{header_segment}.{payload_segment}".encode("utf-8")
+    expected_signature = _sign(signing_input, secret)
+    received_signature = _b64url_decode(signature_segment)
+    if not hmac.compare_digest(expected_signature, received_signature):
+        raise InvalidTokenError("Signature verification failed")
+
+    payload = json.loads(_b64url_decode(payload_segment))
+
+    opts = options or {}
+    required_claims = opts.get("require", [])
+    for claim in required_claims:
+        if claim not in payload:
+            raise InvalidTokenError(f"Token missing required claim: {claim}")
+
+    exp = payload.get("exp")
+    if exp is not None:
+        try:
+            exp_value = float(exp)
+        except (TypeError, ValueError) as exc:
+            raise InvalidTokenError("Invalid exp claim") from exc
+        if exp_value < time.time():
+            raise ExpiredSignatureError("Token has expired")
+
+    if issuer and payload.get("iss") != issuer:
+        raise InvalidIssuerError("Invalid issuer")
+
+    verify_aud = opts.get("verify_aud", True)
+    if verify_aud and audience is not None:
+        expected_audiences = {audience} if isinstance(audience, str) else set(audience)
+        token_aud = payload.get("aud")
+        if isinstance(token_aud, str):
+            token_audiences = {token_aud}
+        elif isinstance(token_aud, Iterable):
+            token_audiences = set(token_aud)
+        else:
+            raise InvalidAudienceError("Invalid audience")
+
+        if not token_audiences & expected_audiences:
+            raise InvalidAudienceError("Invalid audience")
+
+    return payload

--- a/backend/app/requirements.in
+++ b/backend/app/requirements.in
@@ -21,6 +21,7 @@ python-dotenv
 python-multipart
 requests
 httpx
+PyJWT
 
 # Payments
 stripe

--- a/backend/app/requirements.txt
+++ b/backend/app/requirements.txt
@@ -22,6 +22,7 @@ python-dotenv==1.0.1
 python-multipart==0.0.9
 requests==2.32.3
 httpx==0.25.2
+PyJWT==2.10.1
 pydantic==2.8.2
 pyyaml==6.0.1
 

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -1,0 +1,85 @@
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import sys
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("SUPABASE_URL", "https://project.supabase.co")
+os.environ.setdefault(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test",
+)
+
+from backend.app.main import AuthenticatedUser, get_current_user, jwt
+
+
+def _make_token(
+    secret: str,
+    expires_in: timedelta,
+    overrides: Optional[Dict[str, Any]] = None,
+) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": "user-123",
+        "iss": "https://project.supabase.co/auth/v1",
+        "aud": "authenticated",
+        "iat": int(now.timestamp()),
+        "exp": int((now + expires_in).timestamp()),
+    }
+    if overrides:
+        payload.update(overrides)
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+@pytest.fixture(autouse=True)
+def configure_env(monkeypatch):
+    secret = "super-secret"
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", secret)
+    monkeypatch.setenv("SUPABASE_URL", "https://project.supabase.co")
+    monkeypatch.setenv("SUPABASE_JWT_AUD", "authenticated")
+    monkeypatch.delenv("SUPABASE_JWT_ISS", raising=False)
+    yield secret
+
+
+def test_get_current_user_accepts_valid_token(configure_env):
+    secret = configure_env
+    token = _make_token(secret, expires_in=timedelta(minutes=5))
+
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    current_user = get_current_user(credentials)
+
+    assert isinstance(current_user, AuthenticatedUser)
+    assert current_user.user_id == "user-123"
+    assert current_user.claims["aud"] == "authenticated"
+
+
+def test_get_current_user_rejects_expired_token(configure_env):
+    secret = configure_env
+    token = _make_token(secret, expires_in=timedelta(minutes=-5))
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as exc:
+        get_current_user(credentials)
+
+    assert exc.value.status_code == 401
+    assert "expired" in exc.value.detail.lower()
+
+
+def test_get_current_user_rejects_tampered_signature(configure_env):
+    secret = configure_env
+    valid_token = _make_token(secret, expires_in=timedelta(minutes=5))
+    tampered_token = valid_token[:-1] + ("A" if valid_token[-1] != "A" else "B")
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=tampered_token)
+
+    with pytest.raises(HTTPException) as exc:
+        get_current_user(credentials)
+
+    assert exc.value.status_code == 401
+    assert "invalid token" in exc.value.detail.lower()


### PR DESCRIPTION
## Summary
- add the PyJWT dependency for the backend and provide an offline fallback implementation
- replace manual token parsing with verified Supabase JWT decoding that supplies the authenticated user to routes
- update routes to rely on the authenticated identity and add regression tests for valid, expired, and tampered tokens

## Testing
- pytest backend/app/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d92ed12ad08328b45230b24028ca1e