### PR TITLE
Align navbar with Revolut-inspired top bar

### DIFF
--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -30,7 +30,7 @@ function Layout({ Component, pageProps }: LayoutProps) {
       router.events.off("routeChangeComplete", handleComplete);
       router.events.off("routeChangeError", handleComplete);
     };
-  }, [router]);
+  }, [router.events]);
 
   useEffect(() => {
     if (!loading && !session && router.pathname !== "/login") {
@@ -38,34 +38,28 @@ function Layout({ Component, pageProps }: LayoutProps) {
     }
   }, [session, loading, router]);
 
-  // Block render until session is resolved
   if (loading) {
-    return (
-      <AuthorityPointLoader/>
-    );
+    return <AuthorityPointLoader />;
   }
 
-
-  return (
-    <div className="min-h-screen flex bg-gray-50">
-
-      {session && <Navbar />}
-      <main
-  className={`flex-1 p-8 transition-all duration-200 ${
-    session ? "md:ml-60 mt-16" : ""
-  }`}
->
-  {pageLoading ? (
-    <div className="flex-1 flex items-center justify-center">
+  const content = pageLoading ? (
+    <div className="flex min-h-[50vh] items-center justify-center">
       <InlineLoader />
     </div>
   ) : (
     <Component {...pageProps} />
-  )}
-</main>
-    </div>
   );
 
+  return (
+    <div className="min-h-screen bg-[#F5F6FB]">
+      {session && <Navbar />}
+      <main className={`${session ? "pt-[140px] md:pt-[120px]" : "pt-6"}`}>
+        <div className="mx-auto w-full max-w-[1180px] px-5 pb-12 sm:px-8">
+          {content}
+        </div>
+      </main>
+    </div>
+  );
 }
 
 export default function MyApp({ Component, pageProps }: AppProps) {

--- a/outreach-frontend/styles/globals.css
+++ b/outreach-frontend/styles/globals.css
@@ -1,38 +1,36 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* --- Apple-style global baseline --- */
-
-/* Light background + smooth text */
-body {
-  @apply bg-gray-50 text-gray-900 antialiased;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  margin: 0;
-  padding: 0;
+:root {
+  --background: #f5f6fb;
+  --foreground: #111321;
 }
 
-/* Consistent root colors */
-:root {
-  --background: #f9fafb;   /* Apple-style light gray */
-  --foreground: #111827;   /* Neutral dark gray */
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: "DM Sans", -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @keyframes progress {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
-}
-
-
-/* Force light UI even in dark mode */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #f9fafb;  /* keep same as light */
-    --foreground: #111827;
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
   }
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #f5f6fb;
+    --foreground: #111321;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the dual-rail navigation with a Revolut-style glassy top bar that mirrors their icon, gradient, and action-pill patterns
- realign the app layout to center content beneath the fixed header and update the global palette to the Revolut background and DM Sans font stack

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "next/typescript")*

------
https://chatgpt.com/codex/tasks/task_e_68daf980ae908328ae1d5f2b016c695a