### PR TITLE
Refresh navigation layout with Revolut-inspired UI

### DIFF
--- a/outreach-frontend/components/Navbar.tsx
+++ b/outreach-frontend/components/Navbar.tsx
@@ -1,425 +1,288 @@
 "use client";
 
-import Link from "next/link";
-import { CreditCard } from "lucide-react";
-import { useRouter } from "next/router";
-import { HouseLineIcon } from "@phosphor-icons/react";
-import {
-  FiHome,
-  FiUpload,
-  FiFileText,
-  FiLogOut,
-  FiBell,
-  FiHelpCircle,
-  FiMenu,
-  FiX,
-} from "react-icons/fi";
-import { supabase } from "../lib/supabaseClient";
 import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import {
+  Home,
+  CreditCard,
+  Wallet2,
+  ShieldCheck,
+  Bell,
+  HelpCircle,
+  Settings,
+  LogOut,
+} from "lucide-react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+  type ComponentType,
+  type CSSProperties,
+  type FocusEvent,
+} from "react";
 import logo from "../pages/logo.png";
-import { useState, useRef, useEffect } from "react";
-import { useAuth } from "../lib/AuthProvider";
-import { motion, AnimatePresence } from "framer-motion";
+import { supabase } from "../lib/supabaseClient";
+
+const classNames = (
+  ...classes: Array<string | false | null | undefined>
+) => classes.filter(Boolean).join(" ");
+
+interface NavItem {
+  key: string;
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  notification?: boolean;
+}
+
+const primaryItems: NavItem[] = [
+  { key: "home", href: "/", label: "Home", icon: Home },
+  { key: "cards", href: "/upload", label: "Cards", icon: CreditCard },
+  { key: "payments", href: "/billing", label: "Payments", icon: Wallet2, notification: true },
+  { key: "security", href: "/jobs", label: "Security", icon: ShieldCheck },
+];
+
+const secondaryItems: NavItem[] = [
+  { key: "settings", href: "/settings", label: "Settings", icon: Settings },
+];
 
 export default function Navbar() {
   const router = useRouter();
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [shinePlayed, setShinePlayed] = useState(false);
+  const [railOpen, setRailOpen] = useState(false);
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+  const tooltipTimer = useRef<NodeJS.Timeout | null>(null);
+  const navRef = useRef<HTMLDivElement | null>(null);
 
-  const [menuOpen, setMenuOpen] = useState(false);
-
-  const { userInfo, loading } = useAuth();
-
-  const iconWrapperRef = useRef<HTMLSpanElement | null>(null);
+  const activeKey = useMemo(() => {
+    const pathname = router.pathname;
+    if (pathname.startsWith("/jobs")) return "security";
+    if (pathname.startsWith("/upload")) return "cards";
+    if (pathname.startsWith("/billing")) return "payments";
+    if (pathname.startsWith("/settings")) return "settings";
+    return "home";
+  }, [router.pathname]);
 
   useEffect(() => {
-    if (router.pathname === "/jobs" && iconWrapperRef.current) {
-      iconWrapperRef.current.animate(
-        [
-          { transform: "rotate(0deg)" },
-          { transform: "rotate(-15deg)" },
-          { transform: "rotate(15deg)" },
-          { transform: "rotate(0deg)" },
-        ],
-        { duration: 300, easing: "ease-in-out" }
-      );
-    }
-  }, [router.pathname]);
+    const targetWidth = railOpen ? getComputedStyle(document.documentElement).getPropertyValue("--rail-expanded") || "256px" : getComputedStyle(document.documentElement).getPropertyValue("--rail-collapsed") || "80px";
+    document.documentElement.style.setProperty("--rail-current", targetWidth.trim());
+  }, [railOpen]);
+
+  useEffect(() => {
+    return () => {
+      document.documentElement.style.setProperty("--rail-current", getComputedStyle(document.documentElement).getPropertyValue("--rail-collapsed") || "80px");
+      if (tooltipTimer.current) {
+        clearTimeout(tooltipTimer.current);
+      }
+    };
+  }, []);
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
     router.push("/login");
   };
 
-  const handleHover = () => {
-    if (iconWrapperRef.current) {
-      iconWrapperRef.current.animate(
-        [
-          { transform: "rotate(0deg)" },
-          { transform: "rotate(-15deg)" },
-          { transform: "rotate(15deg)" },
-          { transform: "rotate(0deg)" },
-        ],
-        { duration: 300, easing: "ease-in-out" }
-      );
+  const handleMouseEnter = (key: string) => {
+    if (tooltipTimer.current) clearTimeout(tooltipTimer.current);
+    tooltipTimer.current = setTimeout(() => setHoveredItem(key), 120);
+  };
+
+  const handleMouseLeave = () => {
+    if (tooltipTimer.current) clearTimeout(tooltipTimer.current);
+    setHoveredItem(null);
+  };
+
+  const handleFocusOut = (event: FocusEvent<HTMLElement>) => {
+    if (!navRef.current) return;
+    const nextTarget = event.relatedTarget as Node | null;
+    if (!nextTarget || !navRef.current.contains(nextTarget)) {
+      setRailOpen(false);
     }
   };
 
+  const renderNavButton = (item: NavItem, isSecondary = false) => {
+    const Icon = item.icon;
+    const isActive = activeKey === item.key;
+    const pillClasses = classNames(
+      "relative flex items-center w-full h-11 gap-3 px-3 transition-all",
+      "duration-[var(--r-fast)] ease-[var(--r-ease)] focus-visible:outline-none",
+      "focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[rgba(127,132,246,0.8)] focus-visible:ring-offset-white",
+      isActive
+        ? "text-[var(--r-primary-ink)] font-semibold"
+        : "text-[#98A2B3] hover:text-[var(--r-on-bg)]"
+    );
 
-
-  useEffect(() => {
-    if (menuOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-  }, [menuOpen]);
-
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setDropdownOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+    const pillStyle: CSSProperties = {
+      borderRadius: "var(--r-radius-squircle)",
+      background: isActive ? "var(--r-active)" : "transparent",
+      boxShadow: isActive ? "inset 0 0 0 1px rgba(127, 132, 246, 0.45)" : "none",
+      transform: isActive ? "translateY(-1px)" : "translateY(0)",
     };
-  }, []);
 
-  // Pull data from userInfo
-  const credits = userInfo?.credits_remaining ?? 0;
-  const userName = loading
-    ? ""
-    : userInfo?.full_name
-      ? userInfo.full_name
-      : "";
-  const avatarUrl = loading ? null : userInfo?.avatar_url || null;
+    const linkContent = (
+      <>
+        {isActive && (
+          <span
+            aria-hidden
+            className="absolute"
+            style={{
+              left: "10px",
+              top: "6px",
+              bottom: "6px",
+              width: "2px",
+              borderRadius: "999px",
+              background: "var(--r-primary)",
+            }}
+          />
+        )}
+        <span className="flex items-center gap-3 pl-2">
+          <span className="relative flex items-center justify-center" style={{ width: "40px", height: "40px" }}>
+            <Icon
+              className={classNames(
+                "transition-colors duration-[var(--r-fast)]",
+                isActive ? "text-[var(--r-primary-ink)]" : "text-[#98A2B3]"
+            )}
+            style={{ width: "var(--r-icon)", height: "var(--r-icon)" }}
+          />
+          {item.notification && !isActive && (
+            <span
+              className="absolute"
+              style={{
+                top: "6px",
+                right: "8px",
+                width: "6px",
+                height: "6px",
+                borderRadius: "999px",
+                backgroundColor: "var(--r-primary)",
+                boxShadow: "0 0 0 1px #fff",
+              }}
+            />
+          )}
+        </span>
+        <span
+          className={classNames(
+            "text-sm",
+            isActive ? "font-semibold" : "font-medium",
+            !railOpen && "opacity-0 pointer-events-none",
+            railOpen && "opacity-100"
+          )}
+          style={{ transition: `opacity var(--r-fast) var(--r-ease)` }}
+        >
+          {item.label}
+        </span>
+        </span>
+      </>
+    );
+
+    const commonProps = {
+      className: pillClasses,
+      style: pillStyle,
+      onMouseEnter: () => handleMouseEnter(item.key),
+      onMouseLeave: handleMouseLeave,
+      onFocus: () => setRailOpen(true),
+      onBlur: handleFocusOut,
+    };
+
+    if (item.key === "settings" && isSecondary) {
+      return (
+        <button key={item.key} type="button" {...commonProps} onClick={() => router.push(item.href)}>
+          {linkContent}
+        </button>
+      );
+    }
+
+    if (item.key === "logout") {
+      return (
+        <button key={item.key} type="button" {...commonProps} onClick={handleLogout}>
+          {linkContent}
+        </button>
+      );
+    }
+
+    return (
+      <Link key={item.key} href={item.href} {...commonProps}>
+        {linkContent}
+      </Link>
+    );
+  };
+
+  const renderTooltip = (item: NavItem, index: number) => {
+    if (railOpen || hoveredItem !== item.key) return null;
+    const offset = 12 + index * 46;
+    return (
+      <div
+        key={`${item.key}-tooltip`}
+        className="pointer-events-none absolute left-full"
+        style={{
+          top: `${offset}px`,
+          marginLeft: "12px",
+          padding: "6px 12px",
+          borderRadius: "var(--r-radius-squircle)",
+          background: "#fff",
+          boxShadow: "var(--r-shadow-float)",
+          fontSize: "13px",
+          fontWeight: 500,
+          color: "var(--r-on-bg)",
+          opacity: 1,
+          transform: "scale(1)",
+          transition: `opacity var(--r-fast) var(--r-ease), transform var(--r-fast) var(--r-ease)`,
+        }}
+      >
+        {item.label}
+      </div>
+    );
+  };
+
+  const itemsWithLogout = [...secondaryItems, { key: "logout", href: "#", label: "Log out", icon: LogOut }];
 
   return (
     <>
-      {/* ---------------- Desktop Navbar ---------------- */}
-      <div className="hidden lg:flex fixed top-0 left-0 h-screen w-60 bg-white border-r border-gray-100 flex-col font-sans z-50">
-        {/* Top Section: Logo */}
-        <div className="p-6 border-b border-gray-100">
-          <div
-            className="relative group w-[180px] h-[40px] cursor-pointer"
-            onMouseEnter={() => {
-              if (!shinePlayed) setShinePlayed(true);
-            }}
-          >
-            {/* Logo image */}
-            <Image
-              src={logo}
-              alt="AuthorityPoint Logo"
-              fill
-
-            />
-
-            {/* Shimmer overlay, only triggers once */}
-            {shinePlayed && (
-              <motion.div
-                key="shine"
-                className="absolute top-0 left-0 h-full w-full bg-gradient-to-r from-transparent via-white to-transparent"
-                initial={{ x: "-100%" }}
-                animate={{ x: "100%" }}
-                transition={{ duration: 0.8, ease: "easeInOut" }}
-                style={{ mixBlendMode: "screen" }}
-              />
-            )}
-          </div>
-
-        </div>
-
-        {/* Middle Section: Nav Links */}
-        <div className="flex-1 flex flex-col px-4 py-6 gap-y-4">
-
-          <Link
-            href="/"
-            className={`flex items-center px-3 py-2 rounded-lg text-[15px] font-medium transition-all duration-200 ${router.pathname === "/"
-              ? "bg-gray-100 text-gray-900 shadow-sm"
-              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-              }`}
-          >
-            <FiHome className="mr-3 h-5 w-5" />
-            Home
-          </Link>
-          <Link
-            href="/upload"
-            className={`flex items-center transition-colors duration-300 px-3 py-2 rounded-lg text-[15px] font-medium ${router.pathname === "/upload"
-              ? "bg-gray-100 text-gray-900 shadow-sm"
-              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900 hover:"
-              }`}
-          >
-            <FiUpload
-              size={40}
-              className={`transition-colors duration-300 mr-3 h-5 w-5 ${router.pathname === "/upload"
-                ? "fill-blue-400 stroke-black transform transition-transform duration-200 rotate-[90deg]"
-                : "hover:fill-blue-100 hover:stroke-black"
-                }`}
-            />
-            Upload File
-          </Link>
-          {/* <FiUpload
-              size={40}
-              className={`transition-colors duration-300 mr-3 h-5 w-5 ${router.pathname === "/upload"
-                ? "fill-yellow-400 bg-gray-100 stroke-black transform transition-transform duration-150 rotate-[360deg]"
-                : "hover:fill-yellow-400 hover:stroke-black"
-                }`}
-            /> */}
-
-
-
-
-
-
-          <Link
-            href="/jobs"
-            className={`group flex items-center px-3 py-2 rounded-lg text-[15px] font-medium transition-all duration-200 ${router.pathname === "/jobs"
-              ? "bg-gray-100 text-gray-900 shadow-sm"
-              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-              }`}
-            onMouseEnter={handleHover} // hover works everywhere
-          >
-            <span ref={iconWrapperRef} className="mr-3 flex">
-              <FiFileText
-                size={20}
-                className={`h-5 w-5 transition-colors duration-300 ${router.pathname === "/jobs"
-                  ? "fill-yellow-100 stroke-black"
-                  : "group-hover:fill-yellow-100 group-hover:stroke-black"
-                  }`}
-              />
-            </span>
-            <span
-              className={`transition-colors duration-300 ${router.pathname === "/jobs"
-                ? "text-gray-900"
-                : "group-hover:text-gray-900"
-                }`}
-            >
-              Your Files
-            </span>
-          </Link>
-
-          <Link
-            href="/billing"
-            className={`flex items-center px-3 py-2 rounded-lg text-[15px] font-medium transition-all duration-200 ${router.pathname === "/billing"
-              ? "bg-gray-100 text-gray-900 shadow-sm"
-              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-              }`}
-          >
-            <CreditCard className="mr-3 h-5 w-5" />
-            Plans & Billing
-          </Link>
-          <Link
-            href="/test-button"
-            className={`flex items-center px-3 py-2 rounded-lg text-[15px] font-medium transition-all duration-200 ${router.pathname === "/billing"
-              ? "bg-gray-100 text-gray-900 shadow-sm"
-              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-              }`}
-          >
-            <CreditCard className="mr-3 h-5 w-5" />
-            Test UI button
-          </Link>
-        </div>
-
-        {/* Bottom Section: Logout */}
-        <div className="p-4 border-t border-gray-100">
-          <button
-            onClick={handleLogout}
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl font-medium text-white text-[15px] tracking-tight shadow-sm transition-all duration-300"
-            style={{
-              background: "linear-gradient(#5a5a5a, #1c1c1c)",
-              fontFamily:
-                '-apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif',
-            }}
-          >
-            <FiLogOut className="h-5 w-5" />
-            Logout
-          </button>
-        </div>
-      </div>
-
-      {/* ---------------- Desktop Top Strip ---------------- */}
-      <div className="hidden lg:flex fixed top-0 left-60 right-0 h-16 border-b border-gray-100 bg-white items-center justify-between px-8 shadow-sm z-40">
-        <div className="flex-1" />
-        <div className="flex items-center gap-6 ml-6">
-         <div
-  style={{
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "flex-end", // ensures right alignment with icons
-    minWidth: "120px",          // keeps consistent spacing even when numbers grow
-    fontFamily:
-      '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif',
-    color: "#111111",
-    fontSize: "14px",
-    fontWeight: 500,
-    letterSpacing: "-0.2px",
-  }}
->
-  {credits.toLocaleString()} lines
-</div>
-
-          <FiBell className="w-5 h-5 cursor-pointer text-gray-500 hover:text-gray-900 transition" />
-          <FiHelpCircle className="w-5 h-5 cursor-pointer text-gray-500 hover:text-gray-900 transition" />
-          <div className="relative" ref={dropdownRef}>
-            <button
-              onClick={() => setDropdownOpen(!dropdownOpen)}
-              className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 transition"
-            >{loading ? (
-              <div className="w-8 h-8 rounded-full bg-gray-200 animate-pulse" />
-            ) :
-              avatarUrl ? (
-                <Image
-                  src={avatarUrl}
-                  alt={userName}
-                  width={32}
-                  height={32}
-                  className="rounded-full object-cover"
-                />
-              ) : (
-                <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center font-medium text-gray-700">
-                  {userName.charAt(0)}
-                </div>
-              )}
-              <span className="font-medium text-gray-700 text-sm">
-                {userName}
-              </span>
-            </button>
-            {dropdownOpen && (
-              <div className="absolute right-0 mt-2 w-44 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden">
-                <button className="w-full text-left px-4 py-2 text-gray-700 hover:bg-gray-50">
-                  Account
-                </button>
-                <button
-                  onClick={handleLogout}
-                  className="w-full text-left px-4 py-2 text-gray-700 hover:bg-gray-50"
-                >
-                  Sign out
-                </button>
-              </div>
-            )}
+      <aside
+        className="hidden lg:flex fixed top-0 left-0 z-50 h-screen flex-col border-r"
+        ref={navRef}
+        style={{
+          width: railOpen ? "var(--rail-expanded)" : "var(--rail-collapsed)",
+          borderColor: "var(--r-border)",
+          backgroundColor: "#fff",
+          transition: `width var(--r-med) var(--r-ease)`,
+        }}
+        onMouseEnter={() => setRailOpen(true)}
+        onMouseLeave={() => {
+          setRailOpen(false);
+          handleMouseLeave();
+        }}
+      >
+        <div className="flex items-center" style={{ padding: "12px 20px 16px" }}>
+          <div className="relative" style={{ width: railOpen ? "168px" : "40px", height: "40px", transition: `width var(--r-med) var(--r-ease)` }}>
+            <Image src={logo} alt="AuthorityPoint" fill sizes="(max-width: 256px) 100vw" style={{ objectFit: "contain" }} />
           </div>
         </div>
-      </div>
-
-      {/* ---------------- Mobile Navbar ---------------- */}
-      {/* --- Mobile Navbar --- */}
-      {/* ---------------- Mobile Navbar ---------------- */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 z-50">
-        <div className="flex items-center justify-between px-4 h-16 bg-white border-b border-gray-200">
-          {/* Hamburger / X */}
-          <button
-            onClick={() => setMenuOpen(!menuOpen)}
-            className="relative w-8 h-8 flex flex-col justify-center items-center"
-          >
-            <motion.span
-              animate={menuOpen ? { rotate: 45, y: 6 } : { rotate: 0, y: 0 }}
-              transition={{ duration: 0.15 }}
-              className="block w-6 h-0.5 bg-gray-800 rounded-sm mb-1"
-            />
-            <motion.span
-              animate={menuOpen ? { opacity: 0 } : { opacity: 1 }}
-              transition={{ duration: 0.1 }}
-              className="block w-6 h-0.5 bg-gray-800 rounded-sm mb-1"
-            />
-            <motion.span
-              animate={menuOpen ? { rotate: -45, y: -6 } : { rotate: 0, y: 0 }}
-              transition={{ duration: 0.15 }}
-              className="block w-6 h-0.5 bg-gray-800 rounded-sm"
-            />
-          </button>
-
-          {/* Logo */}
-          <Image src={logo} alt="AuthorityPoint Logo" width={120} height={28} priority />
-
-          {/* Avatar */}
-          <div className="flex items-center gap-3">
-            {loading ? (
-              <div className="w-8 h-8 rounded-full bg-gray-200 animate-pulse" />
-            ) : avatarUrl ? (
-              <Image
-                src={avatarUrl}
-                alt={userName}
-                width={32}
-                height={32}
-                className="rounded-full object-cover"
-              />
-            ) : (
-              <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center font-medium text-gray-700">
-                {userName.charAt(0)}
-              </div>
-            )}
-          </div>
+        <div className="flex-1 flex flex-col" style={{ gap: "8px", padding: "12px" }}>
+          {primaryItems.map((item) => renderNavButton(item))}
         </div>
-      </div>
-
-      {/* Overlay (fixed, disables scroll) */}
-      <AnimatePresence>
-        {menuOpen && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 0.4 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="fixed top-16 left-0 right-0 bottom-0 bg-black z-40"
-            onClick={() => setMenuOpen(false)}
-          />
+        <div className="mt-auto w-full" style={{ borderTop: `1px solid var(--r-border)`, padding: "12px" }}>
+          {itemsWithLogout.map((item) => renderNavButton(item, true))}
+        </div>
+        {!railOpen && (
+          <div className="pointer-events-none absolute" style={{ top: 12, left: "100%" }}>
+            {primaryItems.map((item, index) => renderTooltip(item, index))}
+          </div>
         )}
-      </AnimatePresence>
+      </aside>
 
-      {/* Dropdown Menu (fixed under navbar) */}
-      <AnimatePresence>
-        {menuOpen && (
-          <motion.div
-            initial={{ scaleY: 0, opacity: 0 }}
-            animate={{ scaleY: 1, opacity: 1 }}
-            exit={{ scaleY: 0, opacity: 0 }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
-            className="fixed top-16 left-0 right-0 bg-white border-b border-gray-200 shadow-lg z-50 origin-top"
-          >
-            <motion.ul
-              initial="hidden"
-              animate="show"
-              exit="hidden"
-              variants={{
-                hidden: {},
-                show: { transition: { staggerChildren: 0.03 } },
-              }}
-              className="flex flex-col px-6 py-4"
-            >
-              {[
-                { name: "Home", href: "/" },
-                { name: "Upload File", href: "/upload" },
-                { name: "Your Files", href: "/jobs" },
-                { name: "Plans & Billing", href: "/billing" },
-              ].map((item) => (
-                <motion.li
-                  key={item.name}
-                  variants={{
-                    hidden: { opacity: 0, y: -5 },
-                    show: { opacity: 1, y: 0 },
-                  }}
-                  transition={{ duration: 0.15 }}
-                  className="py-3 text-base font-medium text-gray-800 border-b last:border-0 border-gray-100"
-                >
-                  <Link href={item.href} onClick={() => setMenuOpen(false)}>
-                    {item.name}
-                  </Link>
-                </motion.li>
-              ))}
-            </motion.ul>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-
+      {/* Mobile top bar */}
+      <div className="lg:hidden fixed top-0 left-0 right-0 z-40" style={{ background: "#fff", borderBottom: `1px solid var(--r-border)` }}>
+        <div className="flex items-center justify-between px-4" style={{ height: "64px" }}>
+          <Link href="/">
+            <Image src={logo} alt="AuthorityPoint" width={120} height={32} />
+          </Link>
+          <div className="flex items-center gap-4 text-[#98A2B3]">
+            <Bell className="w-5 h-5" />
+            <HelpCircle className="w-5 h-5" />
+          </div>
+        </div>
+      </div>
     </>
   );
 }

--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -3,9 +3,21 @@ import type { AppProps } from "next/app";
 import Navbar from "../components/Navbar";
 import { AuthProvider, useAuth } from "../lib/AuthProvider";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, useRef, type ComponentType } from "react";
 import AuthorityPointLoader from "../components/AuthorityPointLoader";
 import InlineLoader from "@/components/InlineLoader";
+import { supabase } from "../lib/supabaseClient";
+import { ArrowUpRight, FileText, IdCard } from "lucide-react";
+
+type Action = {
+  label: string;
+  onClick: () => void;
+  Icon: ComponentType<{ className?: string }>;
+};
+
+const classNames = (
+  ...classes: Array<string | false | null | undefined>
+) => classes.filter(Boolean).join(" ");
 
 interface LayoutProps {
   Component: AppProps["Component"];
@@ -13,12 +25,20 @@ interface LayoutProps {
 }
 
 function Layout({ Component, pageProps }: LayoutProps) {
-  const { session, loading } = useAuth();
+  const { session, loading, userInfo } = useAuth();
   const router = useRouter();
   const [pageLoading, setPageLoading] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const profileRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const [headerElevated, setHeaderElevated] = useState(false);
 
   useEffect(() => {
-    const handleStart = () => setPageLoading(true);
+    const handleStart = () => {
+      setProfileOpen(false);
+      setPageLoading(true);
+    };
     const handleComplete = () => setPageLoading(false);
 
     router.events.on("routeChangeStart", handleStart);
@@ -38,34 +58,248 @@ function Layout({ Component, pageProps }: LayoutProps) {
     }
   }, [session, loading, router]);
 
-  // Block render until session is resolved
+  useEffect(() => {
+    const clickHandler = (event: MouseEvent) => {
+      if (
+        profileRef.current &&
+        !profileRef.current.contains(event.target as Node)
+      ) {
+        setProfileOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", clickHandler);
+    return () => document.removeEventListener("mousedown", clickHandler);
+  }, []);
+
+  useEffect(() => {
+    if (!headerRef.current || !sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setHeaderElevated(!entry.isIntersecting);
+      },
+      { threshold: 1.0 }
+    );
+
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, [session]);
+
+  const isLoginRoute = router.pathname === "/login";
+
   if (loading) {
+    return <AuthorityPointLoader />;
+  }
+
+  if (!session && !isLoginRoute) {
     return (
-      <AuthorityPointLoader/>
+      <div className="min-h-screen flex items-center justify-center bg-[var(--r-bg)]">
+        <InlineLoader />
+      </div>
     );
   }
 
+  const showShell = Boolean(session && !isLoginRoute);
 
-  return (
-    <div className="min-h-screen flex bg-gray-50">
+  const pageTitle = useMemo(() => {
+    const path = router.pathname;
+    if (path.startsWith("/upload")) return "Upload File";
+    if (path.startsWith("/billing")) return "Plans & Billing";
+    if (path.startsWith("/jobs/[")) return "File Details";
+    if (path.startsWith("/jobs")) return "Past Files";
+    if (path.startsWith("/settings")) return "Account Settings";
+    return "Home";
+  }, [router.pathname]);
 
-      {session && <Navbar />}
-      <main
-  className={`flex-1 p-8 transition-all duration-200 ${
-    session ? "md:ml-60 mt-16" : ""
-  }`}
->
-  {pageLoading ? (
-    <div className="flex-1 flex items-center justify-center">
-      <InlineLoader />
-    </div>
-  ) : (
-    <Component {...pageProps} />
-  )}
-</main>
-    </div>
+  const actions: Action[] = useMemo(
+    () => [
+      {
+        label: "Move money",
+        onClick: () => router.push("/upload"),
+        Icon: ArrowUpRight,
+      },
+      {
+        label: "Statements",
+        onClick: () => router.push("/jobs"),
+        Icon: FileText,
+      },
+      {
+        label: "Account",
+        onClick: () => router.push("/billing"),
+        Icon: IdCard,
+      },
+    ],
+    [router]
   );
 
+  const creditsRemaining = userInfo?.credits_remaining ?? 0;
+  const resolvedName =
+    userInfo?.full_name || session?.user?.email?.split("@")[0] || "";
+  const displayName = resolvedName || "User";
+  const avatarUrl = userInfo?.avatar_url || null;
+  const displayInitial = displayName.charAt(0).toUpperCase();
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    setProfileOpen(false);
+    router.push("/login");
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--r-bg)] text-[var(--r-on-bg)]">
+      {showShell && <Navbar />}
+      <main
+        className={classNames(
+          "min-h-screen transition-[padding] duration-[var(--r-med)] ease-[var(--r-ease)]",
+          showShell && "pt-[88px] lg:pt-10 lg:pl-[calc(var(--rail-current)+32px)]"
+        )}
+      >
+        {showShell ? (
+          <div className="px-4 pb-10 sm:px-8 lg:px-12">
+            <div className="max-w-6xl mx-auto">
+              <section
+                className="relative overflow-hidden bg-white"
+                style={{
+                  borderRadius: "var(--r-radius-card)",
+                  boxShadow: "var(--r-shadow-card)",
+                }}
+              >
+                <div
+                  ref={sentinelRef}
+                  aria-hidden
+                  className="h-px"
+                  style={{ opacity: 0 }}
+                />
+                <div
+                  ref={headerRef}
+                  className="sticky top-0 z-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+                  style={{
+                    padding: "24px",
+                    background: "#fff",
+                    borderBottom: "1px solid var(--r-border)",
+                    boxShadow: headerElevated ? "var(--r-shadow-float)" : "none",
+                    transition: `box-shadow var(--r-fast) var(--r-ease)`
+                  }}
+                >
+                  <div className="flex flex-col gap-1">
+                    <h1 className="text-[24px] font-semibold tracking-[-0.2px]">
+                      {pageTitle}
+                    </h1>
+                    <span className="text-sm text-[#667085]">
+                      {creditsRemaining.toLocaleString()} lines remaining
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {actions.map(({ label, onClick, Icon }) => (
+                        <button
+                          key={label}
+                          type="button"
+                          onClick={onClick}
+                          className="flex items-center gap-2 text-sm font-medium transition-colors duration-[var(--r-fast)] ease-[var(--r-ease)] hover:bg-[#EFF2F6] active:bg-[var(--r-active)] active:text-[var(--r-primary-ink)]"
+                          style={{
+                            background: "#F5F6F7",
+                            color: "#111827",
+                            border: "1px solid #E6E8EC",
+                            borderRadius: "12px",
+                            padding: "8px 12px",
+                          }}
+                        >
+                          <Icon className="h-[18px] w-[18px]" />
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                    <div
+                      className="hidden sm:flex items-center rounded-full border text-sm font-medium"
+                      style={{
+                        padding: "6px 14px",
+                        background: "var(--r-hover)",
+                        borderColor: "var(--r-border)",
+                      }}
+                    >
+                      <span className="text-[#475467]">Balance</span>
+                      <span className="ml-2 text-[var(--r-primary-ink)]">
+                        {creditsRemaining.toLocaleString()} lines
+                      </span>
+                    </div>
+                    <div className="relative" ref={profileRef}>
+                      <button
+                        type="button"
+                        onClick={() => setProfileOpen((open) => !open)}
+                        className="flex items-center gap-3 transition-colors duration-[var(--r-fast)] ease-[var(--r-ease)] hover:bg-[var(--r-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(127,132,246,0.8)] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                        style={{
+                          padding: "6px 10px",
+                          borderRadius: "999px",
+                        }}
+                      >
+                        {avatarUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={avatarUrl}
+                            alt={displayName}
+                            className="h-9 w-9 rounded-full object-cover"
+                          />
+                        ) : (
+                          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[var(--r-hover)] text-sm font-semibold text-[var(--r-primary-ink)]">
+                            {displayInitial}
+                          </span>
+                        )}
+                        <span className="text-sm font-medium text-[var(--r-on-bg)]">
+                          {displayName}
+                        </span>
+                      </button>
+                      {profileOpen && (
+                        <div
+                          className="absolute right-0 mt-3 w-52 overflow-hidden"
+                          style={{
+                            background: "#fff",
+                            borderRadius: "var(--r-radius-squircle)",
+                            boxShadow: "var(--r-shadow-float)",
+                            border: "1px solid var(--r-border)",
+                          }}
+                        >
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setProfileOpen(false);
+                              router.push("/settings");
+                            }}
+                            className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-[var(--r-on-bg)] transition-colors duration-[var(--r-fast)] ease-[var(--r-ease)] hover:bg-[var(--r-hover)]"
+                          >
+                            Settings
+                          </button>
+                          <button
+                            type="button"
+                            onClick={handleLogout}
+                            className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-[#FF4D4F] transition-colors duration-[var(--r-fast)] ease-[var(--r-ease)] hover:bg-[var(--r-hover)]"
+                          >
+                            Sign out
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div style={{ padding: "24px" }}>
+                  {pageLoading ? (
+                    <div className="flex min-h-[240px] items-center justify-center">
+                      <InlineLoader />
+                    </div>
+                  ) : (
+                    <Component {...pageProps} />
+                  )}
+                </div>
+              </section>
+            </div>
+          </div>
+        ) : (
+          <Component {...pageProps} />
+        )}
+      </main>
+    </div>
+  );
 }
 
 export default function MyApp({ Component, pageProps }: AppProps) {

--- a/outreach-frontend/pages/settings.tsx
+++ b/outreach-frontend/pages/settings.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useAuth } from "../lib/AuthProvider";
+
+export default function SettingsPage() {
+  const { userInfo, session } = useAuth();
+
+  if (!session) {
+    return (
+      <div className="flex min-h-[240px] items-center justify-center text-sm text-[#667085]">
+        You need to be signed in to view settings.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold text-[var(--r-on-bg)]">Profile</h2>
+        <div className="grid gap-3 text-sm text-[#475467] sm:grid-cols-2">
+          <div>
+            <span className="font-medium text-[var(--r-on-bg)]">Name</span>
+            <p>{userInfo?.full_name || session.user.email}</p>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--r-on-bg)]">Email</span>
+            <p>{session.user.email}</p>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--r-on-bg)]">Plan</span>
+            <p>{userInfo?.user?.plan_type || "Free"}</p>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--r-on-bg)]">Subscription status</span>
+            <p>{userInfo?.user?.subscription_status || "inactive"}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold text-[var(--r-on-bg)]">Usage</h2>
+        <div className="grid gap-3 text-sm text-[#475467] sm:grid-cols-2">
+          <div>
+            <span className="font-medium text-[var(--r-on-bg)]">Credits remaining</span>
+            <p>{userInfo?.credits_remaining ?? 0}</p>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--r-on-bg)]">Maximum credits</span>
+            <p>{userInfo?.max_credits ?? 0}</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/outreach-frontend/styles/globals.css
+++ b/outreach-frontend/styles/globals.css
@@ -2,37 +2,65 @@
 @tailwind components;
 @tailwind utilities;
 
-/* --- Apple-style global baseline --- */
+:root {
+  --r-font-sans: "Aeonik Pro", "Aeonik", system-ui, -apple-system, "Segoe UI", "Inter", "Roboto", "Arial", sans-serif;
+  --r-bg: #FFFFFF;
+  --r-on-bg: #191C1F;
+  --r-primary: #7F84F6;
+  --r-primary-ink: #0D1168;
+  --r-accent-1: #6E4CE5;
+  --r-accent-2: #81B2F1;
+  --r-border: #E9ECEF;
+  --r-hover: #F5F7FA;
+  --r-active: #EEF2FF;
+  --r-radius-squircle: 16px;
+  --r-radius-card: 20px;
+  --r-shadow-card: 0 2px 12px rgba(16, 24, 40, 0.06);
+  --r-shadow-float: 0 8px 24px rgba(16, 24, 40, 0.1);
+  --r-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --r-fast: 140ms;
+  --r-med: 220ms;
+  --r-icon: 20px;
+  --r-pad-1: 8px;
+  --r-pad-2: 12px;
+  --r-pad-3: 16px;
+  --r-pad-4: 20px;
+  --rail-collapsed: 80px;
+  --rail-expanded: 256px;
+  --rail-current: var(--rail-collapsed);
+}
 
-/* Light background + smooth text */
+* {
+  box-sizing: border-box;
+}
+
+html,
 body {
-  @apply bg-gray-50 text-gray-900 antialiased;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--r-font-sans);
+  color: var(--r-on-bg);
+  background: var(--r-bg);
   margin: 0;
   padding: 0;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* Consistent root colors */
-:root {
-  --background: #f9fafb;   /* Apple-style light gray */
-  --foreground: #111827;   /* Neutral dark gray */
+button,
+input,
+select,
+textarea {
+  font: inherit;
 }
 
-@keyframes progress {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+::selection {
+  background: rgba(127, 132, 246, 0.18);
 }
 
-
-/* Force light UI even in dark mode */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #f9fafb;  /* keep same as light */
-    --foreground: #111827;
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
 }


### PR DESCRIPTION
## Summary
- establish global Revolut-like design tokens and motion defaults shared across the frontend
- replace the sidebar with a collapsible Revolut-style rail, hover/focus interactions, and new mobile top bar treatment
- rebuild the application shell to present content inside a floating page sheet with an updated header, actions, and profile menu, plus add a lightweight account settings page

## Testing
- npm run lint *(fails: ESLint config "next/typescript" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db9632bc0c8328b2f371f9a41913dd