### PR TITLE
Align Revolut-style layout spacing

### DIFF
--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -47,22 +47,33 @@ function Layout({ Component, pageProps }: LayoutProps) {
 
 
   return (
-    <div className="min-h-screen flex bg-gray-50">
-
+    <div className="min-h-screen flex bg-[#F7F7F7]">
       {session && <Navbar />}
       <main
-  className={`flex-1 p-8 transition-all duration-200 ${
-    session ? "md:ml-60 mt-16" : ""
-  }`}
->
-  {pageLoading ? (
-    <div className="flex-1 flex items-center justify-center">
-      <InlineLoader />
-    </div>
-  ) : (
-    <Component {...pageProps} />
-  )}
-</main>
+        className={`flex-1 flex flex-col transition-all duration-200 ${
+          session ? "lg:ml-[108px] mt-16 px-4 sm:px-8 lg:px-8 xl:px-12 pb-10" : ""
+        }`}
+      >
+        {session ? (
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-t-[32px] bg-white shadow-sm">
+            {pageLoading ? (
+              <div className="flex flex-1 items-center justify-center px-6 py-8 sm:px-8 lg:px-10">
+                <InlineLoader />
+              </div>
+            ) : (
+              <div className="flex-1 px-6 py-8 sm:px-8 lg:px-10">
+                <Component {...pageProps} />
+              </div>
+            )}
+          </div>
+        ) : pageLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <InlineLoader />
+          </div>
+        ) : (
+          <Component {...pageProps} />
+        )}
+      </main>
     </div>
   );
 

--- a/outreach-frontend/styles/globals.css
+++ b/outreach-frontend/styles/globals.css
@@ -6,7 +6,8 @@
 
 /* Light background + smooth text */
 body {
-  @apply bg-gray-50 text-gray-900 antialiased;
+  background-color: #f7f7f7;
+  @apply text-gray-900 antialiased;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 0;
@@ -14,7 +15,7 @@ body {
 
 /* Consistent root colors */
 :root {
-  --background: #f9fafb;   /* Apple-style light gray */
+  --background: #f7f7f7;   /* Revolut-style light gray */
   --foreground: #111827;   /* Neutral dark gray */
 }
 
@@ -39,7 +40,7 @@ a:active { background: transparent !important; }
 /* Force light UI even in dark mode */
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #f9fafb;  /* keep same as light */
+    --background: #f7f7f7;  /* keep same as light */
     --foreground: #111827;
   }
 }


### PR DESCRIPTION
## Summary
- update the global background token to use the Revolut grey used by the navbar
- wrap authenticated routes in a rounded white surface that mirrors Revolut’s curved page background
- preserve loading states inside the new surface so transitions remain centered
- align the authenticated layout margin with the fixed navbar width so the white surface matches Revolut's left spacing

## Testing
- npm run lint *(fails: ESLint config "next/typescript" is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc41c30aa083289e0072792bd09c1d