### PR TITLE
Add stripe event id tracking for ledger entries

### DIFF
--- a/supabase/migrations/20240508120000_add_stripe_event_id_to_ledger.sql
+++ b/supabase/migrations/20240508120000_add_stripe_event_id_to_ledger.sql
@@ -1,0 +1,7 @@
+-- Add stripe_event_id column to ledger for webhook idempotency
+ALTER TABLE public.ledger
+    ADD COLUMN IF NOT EXISTS stripe_event_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ledger_stripe_event_id_idx
+    ON public.ledger (stripe_event_id)
+    WHERE stripe_event_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- capture the Stripe webhook event id and include it on ledger records
- switch ledger writes to an upsert on `stripe_event_id` to avoid duplicate inserts on retries
- add a Supabase migration that adds the column and unique index for `stripe_event_id`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16c7361108328a4e38a900e1f23f1