### PR TITLE
Make credit deduction atomic

### DIFF
--- a/backend/supabase/deduct_credits.sql
+++ b/backend/supabase/deduct_credits.sql
@@ -1,0 +1,19 @@
+-- Atomic credit deduction helper for Supabase/Postgres
+-- Ensures we only subtract credits when the user has enough remaining.
+create or replace function public.deduct_credits(
+    p_user_id uuid,
+    p_amount integer
+)
+returns table(success boolean, credits_remaining integer)
+language sql
+security definer
+set search_path = public
+as $$
+    update profiles
+       set credits_remaining = credits_remaining - p_amount
+     where id = p_user_id
+       and credits_remaining >= p_amount
+    returning true as success, credits_remaining;
+$$;
+
+grant execute on function public.deduct_credits(uuid, integer) to authenticated, service_role;


### PR DESCRIPTION
## Summary
- add a Supabase SQL function that atomically deducts credits when enough balance remains
- update the job processor to call the new RPC and gate ledger entries on a successful deduction
- align the local SQLite helper with the atomic deduction logic to prevent negative balances

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1733e851c832886158f56ef5e9afd