### PR TITLE
Remove placeholder RQ row enqueues

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 import os
 import logging
 from . import db, jobs
-from backend.app.queue_utils import process_row
 from .supabase_client import supabase
 from supabase import create_client
 from fastapi import APIRouter, Body
@@ -621,10 +620,6 @@ async def create_job(
             raise HTTPException(status_code=500, detail="Failed to insert job")
 
         job = result.data[0]
-
-        # --- Step 2: enqueue each row into Redis ---
-        for row_number in range(1, row_count + 1):
-            q.enqueue(process_row, row_number)
 
         return {"id": job["id"], "status": job["status"], "rows": row_count}
 

--- a/backend/app/queue_utils.py
+++ b/backend/app/queue_utils.py
@@ -25,9 +25,3 @@ def worker_loop():
             time.sleep(2)  # nothing to do
 
 
-# --- New RQ worker task for parallel processing ---
-def process_row(row_number: int):
-    print(f"[RQ Worker] Processing row {row_number}...")
-    time.sleep(2)  # simulate API call
-    print(f"[RQ Worker] Finished row {row_number}")
-    return f"row {row_number} done"


### PR DESCRIPTION
## Summary
- stop the /jobs endpoint from enqueuing placeholder per-row tasks when a job is created
- delete the temporary process_row helper that simulated per-row work so that only real job processing remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b8eb63dc83288351326fb891bc09