### PR TITLE
Allow configuring Redis via URL

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -18,7 +18,8 @@ from rq import get_current_job
 # -----------------------------
 # Redis connection
 # -----------------------------
-redis_conn = redis.Redis(host="redis", port=6379, decode_responses=False)
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+redis_conn = redis.from_url(redis_url, decode_responses=False)
 queue = rq.Queue("default", connection=redis_conn)
 
 

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,8 +1,10 @@
+import os
 import redis
 from rq import Worker, Connection
 
 if __name__ == "__main__":
-    redis_conn = redis.Redis(host="redis", port=6379)
+    redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+    redis_conn = redis.from_url(redis_url)
     with Connection(redis_conn):
         worker = Worker(["default"])
         worker.work()


### PR DESCRIPTION
## Summary
- load the Redis connection URL from the REDIS_URL environment variable in the dispatcher
- update the worker CLI to use the same REDIS_URL-based connection configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c2de3bd48328b1fb4382de6570df