### PR TITLE
Align Redis clients with REDIS_URL configuration

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -18,7 +18,8 @@ from rq import get_current_job
 # -----------------------------
 # Redis connection
 # -----------------------------
-redis_conn = redis.Redis(host="redis", port=6379, decode_responses=False)
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+redis_conn = redis.from_url(redis_url, decode_responses=False)
 queue = rq.Queue("default", connection=redis_conn)
 
 

--- a/backend/app/producer.py
+++ b/backend/app/producer.py
@@ -1,13 +1,14 @@
+import os
 import redis
 import rq
 import uuid
-import os
 from backend.app.jobs import process_job
 
 # -----------------------------
 # Redis connection
 # -----------------------------
-redis_conn = redis.Redis(host="redis", port=6379, decode_responses=True)
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+redis_conn = redis.from_url(redis_url, decode_responses=True)
 queue = rq.Queue("default", connection=redis_conn)
 
 # -----------------------------

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,8 +1,10 @@
+import os
 import redis
 from rq import Worker, Connection
 
 if __name__ == "__main__":
-    redis_conn = redis.Redis(host="redis", port=6379)
+    redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+    redis_conn = redis.from_url(redis_url, decode_responses=False)
     with Connection(redis_conn):
         worker = Worker(["default"])
         worker.work()


### PR DESCRIPTION
## Summary
- ensure the RQ worker creates its Redis client from REDIS_URL with binary responses
- update the producer to honor REDIS_URL while keeping decoded responses for convenience

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c2de3bd48328b1fb4382de6570df