### PR TITLE
Add external_id column to ledger table for job credit idempotency

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -30,6 +30,92 @@ RAW_CHUNK_BASE_DIR = "/data/raw_chunks"
 RAW_CHUNK_BUCKET = "inputs"
 
 
+class InsufficientCreditsError(Exception):
+    """Raised when a user does not have enough credits for a job."""
+
+
+class CreditDeductionFailed(RuntimeError):
+    """Raised when a credit deduction partially succeeds but downstream work fails."""
+
+    def __init__(self, message: str, previous_balance: Optional[int] = None):
+        super().__init__(message)
+        self.previous_balance = previous_balance
+
+
+def _is_duplicate_key_error(error) -> bool:
+    message = ""
+    if error is None:
+        return False
+    if isinstance(error, dict):
+        message = error.get("message") or json.dumps(error)
+    else:
+        message = str(error)
+    message = message.lower()
+    return "duplicate key" in message or "already exists" in message
+
+
+def _begin_job_ledger_event(job_id: str, event_type: str, *, supabase_client=None) -> bool:
+    supabase_client = supabase_client or supabase
+    payload = {"job_id": job_id, "event_type": event_type}
+    try:
+        response = supabase_client.table("job_ledger_events").insert(payload).execute()
+    except Exception as exc:
+        if _is_duplicate_key_error(exc):
+            return False
+        raise
+
+    if _is_duplicate_key_error(getattr(response, "error", None)):
+        return False
+
+    error = getattr(response, "error", None)
+    if error:
+        raise RuntimeError(
+            f"Failed to insert job ledger event for {job_id} ({event_type}): {error}"
+        )
+
+    return True
+
+
+def _finalize_job_ledger_event(
+    job_id: str,
+    event_type: str,
+    ledger_row: Optional[dict],
+    *,
+    supabase_client=None,
+):
+    supabase_client = supabase_client or supabase
+    ledger_id = None
+    if isinstance(ledger_row, dict):
+        ledger_id = ledger_row.get("id")
+
+    if ledger_id:
+        supabase_client.table("job_ledger_events").update({"ledger_id": ledger_id}).eq(
+            "job_id", job_id
+        ).eq("event_type", event_type).execute()
+
+
+def _delete_job_ledger_event(job_id: str, event_type: str, *, supabase_client=None):
+    supabase_client = supabase_client or supabase
+    try:
+        supabase_client.table("job_ledger_events").delete().eq("job_id", job_id).eq(
+            "event_type", event_type
+        ).execute()
+    except Exception:
+        # Best effort cleanup; errors here should not mask the original failure.
+        pass
+
+
+def _extract_first_row(response) -> Optional[dict]:
+    if not response:
+        return None
+    data = getattr(response, "data", None)
+    if isinstance(data, list) and data:
+        row = data[0]
+        if isinstance(row, dict):
+            return row
+    return None
+
+
 def _ensure_dict(value):
     if not value:
         return {}
@@ -278,6 +364,11 @@ def refund_job_credits(job_id: str, user_id: Optional[str], reason: str = "") ->
         if meta.get("credits_refunded"):
             return False
 
+        event_type = "job_refund"
+        event_started = _begin_job_ledger_event(job_id, event_type)
+        if not event_started:
+            return False
+
         max_attempts = 5
         for _ in range(max_attempts):
             profile_res = (
@@ -310,15 +401,28 @@ def refund_job_credits(job_id: str, user_id: Optional[str], reason: str = "") ->
         else:
             raise RuntimeError("Failed to atomically refund credits")
 
-        supabase.table("ledger").insert(
-            {
-                "user_id": user_id,
-                "change": cost,
-                "amount": 0.0,
-                "reason": f"job refund: {job_id}{' - ' + reason if reason else ''}",
-                "ts": datetime.utcnow().isoformat(),
-            }
-        ).execute()
+        try:
+            ledger_res = supabase.table("ledger").insert(
+                {
+                    "user_id": user_id,
+                    "change": cost,
+                    "amount": 0.0,
+                    "reason": f"job refund: {job_id}{' - ' + reason if reason else ''}",
+                    "ts": datetime.utcnow().isoformat(),
+                    "external_id": f"{event_type}:{job_id}",
+                }
+            ).execute()
+
+            if getattr(ledger_res, "error", None):
+                raise RuntimeError(getattr(ledger_res, "error"))
+
+            ledger_row = _extract_first_row(ledger_res)
+            _finalize_job_ledger_event(
+                job_id, event_type, ledger_row, supabase_client=supabase
+            )
+        except Exception:
+            _delete_job_ledger_event(job_id, event_type, supabase_client=supabase)
+            raise
 
         meta["credits_refunded"] = True
         supabase.table("jobs").update({"meta_json": meta}).eq("id", job_id).execute()
@@ -326,8 +430,140 @@ def refund_job_credits(job_id: str, user_id: Optional[str], reason: str = "") ->
         print(f"[Credits] Refunded {cost} credits for job {job_id} ({reason})")
         return True
     except Exception as exc:
+        if 'event_type' in locals():
+            _delete_job_ledger_event(job_id, event_type, supabase_client=supabase)
         print(f"[Credits] Failed to refund credits for job {job_id}: {exc}")
         return False
+
+def _deduct_job_credits(
+    job_id: str,
+    user_id: str,
+    total: int,
+    meta: dict,
+    *,
+    supabase_client=None,
+    max_attempts: int = 5,
+    retry_delay: float = 0.1,
+) -> Tuple[bool, Optional[int]]:
+    supabase_client = supabase_client or supabase
+    event_type = "job_deduction"
+    event_started = _begin_job_ledger_event(
+        job_id, event_type, supabase_client=supabase_client
+    )
+
+    if not event_started:
+        updated = False
+        if meta.get("credit_cost") != total:
+            meta["credit_cost"] = total
+            updated = True
+        if not meta.get("credits_deducted"):
+            meta["credits_deducted"] = True
+            updated = True
+        if "credits_refunded" not in meta:
+            meta["credits_refunded"] = False
+            updated = True
+        if updated:
+            response = (
+                supabase_client.table("jobs")
+                .update({"meta_json": meta})
+                .eq("id", job_id)
+                .execute()
+            )
+            if getattr(response, "error", None):
+                raise RuntimeError(
+                    f"Failed to persist job meta for existing deduction on {job_id}: {response.error}"
+                )
+        return False, None
+
+    deduction_applied_balance: Optional[int] = None
+    try:
+        for _ in range(max_attempts):
+            profile_res = (
+                supabase_client.table("profiles")
+                .select("credits_remaining")
+                .eq("id", user_id)
+                .limit(1)
+                .execute()
+            )
+            previous_balance = (
+                profile_res.data[0]["credits_remaining"] if profile_res.data else 0
+            )
+
+            if previous_balance < total:
+                raise InsufficientCreditsError("Not enough credits")
+
+            update_res = (
+                supabase_client.table("profiles")
+                .update({"credits_remaining": previous_balance - total})
+                .eq("id", user_id)
+                .eq("credits_remaining", previous_balance)
+                .execute()
+            )
+
+            if getattr(update_res, "error", None):
+                raise RuntimeError(getattr(update_res, "error"))
+
+            updated_rows = getattr(update_res, "data", None) or []
+            if updated_rows:
+                deduction_applied_balance = previous_balance
+                ledger_res = (
+                    supabase_client.table("ledger")
+                    .insert(
+                        {
+                            "user_id": user_id,
+                            "change": -total,
+                            "amount": 0.0,
+                            "reason": f"job deduction: {job_id}",
+                            "ts": datetime.utcnow().isoformat(),
+                            "external_id": f"{event_type}:{job_id}",
+                        }
+                    )
+                    .execute()
+                )
+
+                if getattr(ledger_res, "error", None):
+                    raise CreditDeductionFailed(
+                        getattr(ledger_res, "error"), previous_balance
+                    )
+
+                ledger_row = _extract_first_row(ledger_res)
+                _finalize_job_ledger_event(
+                    job_id, event_type, ledger_row, supabase_client=supabase_client
+                )
+
+                meta["credit_cost"] = total
+                meta["credits_deducted"] = True
+                if "credits_refunded" not in meta:
+                    meta["credits_refunded"] = False
+
+                meta_update = (
+                    supabase_client.table("jobs")
+                    .update({"meta_json": meta})
+                    .eq("id", job_id)
+                    .execute()
+                )
+                if getattr(meta_update, "error", None):
+                    raise CreditDeductionFailed(
+                        getattr(meta_update, "error"), previous_balance
+                    )
+
+                return True, previous_balance
+
+            time.sleep(retry_delay)
+
+        raise RuntimeError("Failed to atomically deduct credits")
+    except InsufficientCreditsError:
+        _delete_job_ledger_event(job_id, event_type, supabase_client=supabase_client)
+        raise
+    except CreditDeductionFailed:
+        _delete_job_ledger_event(job_id, event_type, supabase_client=supabase_client)
+        raise
+    except Exception as exc:
+        _delete_job_ledger_event(job_id, event_type, supabase_client=supabase_client)
+        if deduction_applied_balance is not None:
+            raise CreditDeductionFailed(str(exc), deduction_applied_balance) from exc
+        raise
+
 
 def _get_job_timeout():
     try:
@@ -773,78 +1009,38 @@ def process_job(job_id: str):
         lock = redis_conn.lock(lock_name, timeout=30, blocking_timeout=10)
         acquired = False
         deducted = False
-        previous_balance = 0
+        previous_balance: Optional[int] = None
         try:
             acquired = lock.acquire(blocking=True)
             if not acquired:
                 raise RuntimeError("Unable to acquire credit lock")
 
-            max_attempts = 5
-            for _ in range(max_attempts):
-                profile_res = (
-                    supabase.table("profiles")
-                    .select("credits_remaining")
-                    .eq("id", user_id)
-                    .limit(1)
-                    .execute()
+            try:
+                deducted, previous_balance = _deduct_job_credits(
+                    job_id,
+                    user_id,
+                    total,
+                    meta,
+                    supabase_client=supabase,
                 )
-                previous_balance = (
-                    profile_res.data[0]["credits_remaining"] if profile_res.data else 0
-                )
-
-                if previous_balance < total:
-                    supabase.table("jobs").update(
-                        {
-                            "status": "failed",
-                            "finished_at": datetime.utcnow().isoformat() + "Z",
-                            "error": "Not enough credits",
-                        }
-                    ).eq("id", job_id).execute()
-                    return
-
-                update_res = (
-                    supabase.table("profiles")
-                    .update({"credits_remaining": previous_balance - total})
-                    .eq("id", user_id)
-                    .eq("credits_remaining", previous_balance)
-                    .execute()
-                )
-
-                if getattr(update_res, "error", None):
-                    raise RuntimeError(
-                        getattr(update_res, "error", "Failed to update credits")
-                    )
-
-                updated_rows = getattr(update_res, "data", None) or []
-                if updated_rows:
+            except InsufficientCreditsError:
+                supabase.table("jobs").update(
+                    {
+                        "status": "failed",
+                        "finished_at": datetime.utcnow().isoformat() + "Z",
+                        "error": "Not enough credits",
+                    }
+                ).eq("id", job_id).execute()
+                return
+            except CreditDeductionFailed as deduction_exc:
+                if deduction_exc.previous_balance is not None:
                     deducted = True
-                    break
-
-                # Retry if another concurrent update changed the balance
-                time.sleep(0.1)
-
-            if not deducted:
-                raise RuntimeError("Failed to atomically deduct credits")
-
-            supabase.table("ledger").insert(
-                {
-                    "user_id": user_id,
-                    "change": -total,
-                    "amount": 0.0,  # ensure non-null for deductions
-                    "reason": f"job deduction: {job_id}",
-                    "ts": datetime.utcnow().isoformat(),
-                }
-            ).execute()
-
-            meta["credit_cost"] = total
-            meta["credits_deducted"] = True
-            if "credits_refunded" not in meta:
-                meta["credits_refunded"] = False
-            supabase.table("jobs").update({"meta_json": meta}).eq("id", job_id).execute()
+                    previous_balance = deduction_exc.previous_balance
+                raise
 
         except Exception as exc:
             print(f"[Credits] Error while deducting for job {job_id}: {exc}")
-            if deducted:
+            if deducted and previous_balance is not None:
                 try:
                     supabase.table("profiles").update(
                         {"credits_remaining": previous_balance}

--- a/backend/app/tests/test_job_ledger_events.py
+++ b/backend/app/tests/test_job_ledger_events.py
@@ -1,0 +1,248 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("SUPABASE_URL", "https://project.supabase.co")
+os.environ.setdefault(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test",
+)
+
+from backend.app import jobs  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, data=None, error=None):
+        self.data = data or []
+        self.error = error
+
+
+class FakeTable:
+    def __init__(self, supabase, name):
+        self.supabase = supabase
+        self.name = name
+        self._action = None
+        self._payload = None
+        self._filters = {}
+
+    def select(self, _columns):
+        self._action = "select"
+        return self
+
+    def update(self, payload):
+        self._action = "update"
+        self._payload = payload
+        return self
+
+    def insert(self, payload):
+        self._action = "insert"
+        self._payload = payload
+        return self
+
+    def delete(self):
+        self._action = "delete"
+        return self
+
+    def eq(self, column, value):
+        self._filters[column] = value
+        return self
+
+    def limit(self, _value):
+        return self
+
+    def execute(self):
+        return self.supabase._execute(self.name, self._action, self._payload, self._filters)
+
+
+class FakeSupabase:
+    def __init__(self, *, job_id, user_id, balance, cost, meta=None):
+        self.job_id = job_id
+        self.user_id = user_id
+        meta = meta or {
+            "credit_cost": cost,
+            "credits_deducted": False,
+            "credits_refunded": False,
+            "file_path": "test.csv",
+        }
+        self.jobs = {
+            job_id: {
+                "id": job_id,
+                "user_id": user_id,
+                "meta_json": meta,
+            }
+        }
+        self.profiles = {user_id: {"id": user_id, "credits_remaining": balance}}
+        self.ledger_rows = []
+        self.job_ledger_events = {}
+
+    def table(self, name):
+        return FakeTable(self, name)
+
+    # Storage interface placeholders for compatibility
+    class storage:
+        @staticmethod
+        def from_(_bucket):
+            raise NotImplementedError
+
+    def _execute(self, name, action, payload, filters):
+        if name == "jobs":
+            return self._execute_jobs(action, payload, filters)
+        if name == "profiles":
+            return self._execute_profiles(action, payload, filters)
+        if name == "ledger":
+            return self._execute_ledger(action, payload, filters)
+        if name == "job_ledger_events":
+            return self._execute_job_ledger_events(action, payload, filters)
+        raise NotImplementedError(name)
+
+    def _execute_jobs(self, action, payload, filters):
+        job_id = filters.get("id")
+        if action == "select":
+            if job_id and job_id not in self.jobs:
+                return FakeResponse([])
+            rows = [
+                {
+                    "id": job_id or self.job_id,
+                    "user_id": self.user_id,
+                    "meta_json": self.jobs[job_id or self.job_id]["meta_json"],
+                }
+            ]
+            return FakeResponse(rows)
+
+        if action == "update":
+            if not job_id or job_id not in self.jobs:
+                return FakeResponse([])
+            self.jobs[job_id].update(payload)
+            return FakeResponse([self.jobs[job_id]])
+
+        return FakeResponse([])
+
+    def _execute_profiles(self, action, payload, filters):
+        user_id = filters.get("id")
+        if user_id not in self.profiles:
+            return FakeResponse([])
+        profile = self.profiles[user_id]
+
+        if action == "select":
+            return FakeResponse([{ "credits_remaining": profile["credits_remaining"] }])
+
+        if action == "update":
+            expected = filters.get("credits_remaining")
+            if expected is not None and profile["credits_remaining"] != expected:
+                return FakeResponse([])
+            profile.update(payload)
+            return FakeResponse([{ "credits_remaining": profile["credits_remaining"] }])
+
+        return FakeResponse([])
+
+    def _execute_ledger(self, action, payload, _filters):
+        if action != "insert":
+            return FakeResponse([])
+        ledger_id = f"ledger-{len(self.ledger_rows) + 1}"
+        row = {"id": ledger_id, **payload}
+        self.ledger_rows.append(row)
+        return FakeResponse([row])
+
+    def _execute_job_ledger_events(self, action, payload, filters):
+        job_id = filters.get("job_id")
+        event_type = filters.get("event_type")
+        if payload:
+            job_id = job_id or payload.get("job_id")
+            event_type = event_type or payload.get("event_type")
+        key = (job_id, event_type)
+        if action == "insert":
+            if key in self.job_ledger_events:
+                return FakeResponse([], error={"message": "duplicate key value violates unique constraint"})
+            row = {"job_id": key[0], "event_type": key[1], "ledger_id": payload.get("ledger_id")}
+            self.job_ledger_events[key] = row
+            return FakeResponse([row])
+
+        if action == "update":
+            row = self.job_ledger_events.get(key)
+            if not row:
+                return FakeResponse([])
+            row.update(payload)
+            return FakeResponse([row])
+
+        if action == "delete":
+            self.job_ledger_events.pop(key, None)
+            return FakeResponse([])
+
+        return FakeResponse([])
+
+
+@pytest.fixture(autouse=True)
+def fast_sleep(monkeypatch):
+    monkeypatch.setattr(jobs.time, "sleep", lambda _seconds: None)
+
+
+def test_refund_job_credits_is_idempotent(monkeypatch):
+    job_id = "job-123"
+    user_id = "user-123"
+    fake = FakeSupabase(job_id=job_id, user_id=user_id, balance=5, cost=3, meta={
+        "credit_cost": 3,
+        "credits_deducted": True,
+        "credits_refunded": False,
+    })
+
+    monkeypatch.setattr(jobs, "supabase", fake)
+
+    assert jobs.refund_job_credits(job_id, user_id, "test") is True
+    assert fake.profiles[user_id]["credits_remaining"] == 8
+    assert len(fake.ledger_rows) == 1
+    assert fake.ledger_rows[0]["external_id"] == f"job_refund:{job_id}"
+    assert fake.job_ledger_events[(job_id, "job_refund")]["ledger_id"] == "ledger-1"
+
+    # Simulate metadata not marking the refund while the event record exists.
+    fake.jobs[job_id]["meta_json"]["credits_refunded"] = False
+
+    assert jobs.refund_job_credits(job_id, user_id, "test") is False
+    assert fake.profiles[user_id]["credits_remaining"] == 8
+    assert len(fake.ledger_rows) == 1
+
+
+def test_deduct_job_credits_is_idempotent(monkeypatch):
+    job_id = "job-456"
+    user_id = "user-456"
+    fake = FakeSupabase(job_id=job_id, user_id=user_id, balance=10, cost=4)
+
+    monkeypatch.setattr(jobs, "supabase", fake)
+
+    meta = fake.jobs[job_id]["meta_json"]
+    deducted, previous_balance = jobs._deduct_job_credits(
+        job_id,
+        user_id,
+        4,
+        meta,
+        supabase_client=fake,
+    )
+
+    assert deducted is True
+    assert previous_balance == 10
+    assert fake.profiles[user_id]["credits_remaining"] == 6
+    assert len(fake.ledger_rows) == 1
+    assert fake.ledger_rows[0]["external_id"] == f"job_deduction:{job_id}"
+    assert fake.job_ledger_events[(job_id, "job_deduction")]["ledger_id"] == "ledger-1"
+
+    fake.profiles[user_id]["credits_remaining"] = 6
+    fake.jobs[job_id]["meta_json"]["credits_deducted"] = False
+
+    deducted_again, previous_balance_again = jobs._deduct_job_credits(
+        job_id,
+        user_id,
+        4,
+        fake.jobs[job_id]["meta_json"],
+        supabase_client=fake,
+    )
+
+    assert deducted_again is False
+    assert previous_balance_again is None
+    assert fake.profiles[user_id]["credits_remaining"] == 6
+    assert len(fake.ledger_rows) == 1
+    assert fake.job_ledger_events[(job_id, "job_deduction")]["ledger_id"] == "ledger-1"
+    assert fake.jobs[job_id]["meta_json"]["credits_deducted"] is True

--- a/supabase/migrations/20240605000000_create_job_ledger_events.sql
+++ b/supabase/migrations/20240605000000_create_job_ledger_events.sql
@@ -1,0 +1,7 @@
+create table if not exists public.job_ledger_events (
+    job_id uuid not null,
+    event_type text not null,
+    ledger_id uuid,
+    created_at timestamptz not null default now(),
+    constraint job_ledger_events_pkey primary key (job_id, event_type)
+);

--- a/supabase/migrations/20240605010000_add_external_id_to_ledger.sql
+++ b/supabase/migrations/20240605010000_add_external_id_to_ledger.sql
@@ -1,0 +1,2 @@
+alter table if exists public.ledger
+    add column if not exists external_id text;


### PR DESCRIPTION
## Summary
- add a migration that adds the optional external_id column to the ledger table so job credit inserts can include deterministic identifiers without failing

## Testing
- pytest backend/app/tests/test_job_ledger_events.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a6ee4a008328af220ecd7cde695c