### PR TITLE
feat: restyle dashboard to mirror Revolut UI

### DIFF
--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -47,28 +47,35 @@ function Layout({ Component, pageProps }: LayoutProps) {
 
 
   return (
-    <div className="min-h-screen flex bg-[#F7F7F7]">
+    <div className="flex min-h-screen bg-[#F7F7F7]">
       {session && <Navbar />}
       <main
-        className={`flex-1 flex flex-col transition-all duration-200 ${session ? "mt-16 px-0 pb-10" : ""
-          }`}
+        className={`flex-1 transition-all duration-200 ${
+          session ? "flex flex-col px-4 py-8 sm:px-10 lg:ml-[108px] lg:px-16" : "flex"
+        }`}
       >
-<div className="flex min-h-0 flex-1 flex-col overflow-hidden 
-                rounded-[32px] bg-white shadow-sm 
-                ml-0 lg:ml-[108px] mr-4">
-          {pageLoading ? (
-            <div className="flex flex-1 items-center justify-center px-6 py-8 sm:px-8 lg:px-10">
-              <InlineLoader />
+        {session ? (
+          <div className="mx-auto flex min-h-full w-full max-w-5xl flex-1 flex-col">
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[32px] border border-[#E2E2E7] bg-white shadow-[0_32px_80px_rgba(15,23,42,0.08)]">
+              {pageLoading ? (
+                <div className="flex flex-1 items-center justify-center px-8 py-10">
+                  <InlineLoader />
+                </div>
+              ) : (
+                <div className="flex-1 px-6 py-8 sm:px-10 sm:py-10 lg:px-12">
+                  <Component {...pageProps} />
+                </div>
+              )}
             </div>
-          ) : (
-            <div className="flex-1 px-6 py-8 sm:px-8 lg:px-10">
-              <Component {...pageProps} />
-            </div>
-          )}
-        </div>
+          </div>
+        ) : pageLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <InlineLoader />
+          </div>
+        ) : (
+          <Component {...pageProps} />
+        )}
       </main>
-
-
     </div>
   );
 

--- a/outreach-frontend/pages/index.tsx
+++ b/outreach-frontend/pages/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useAuth } from "../lib/AuthProvider";
 import { buyCredits } from "../lib/api";
 import { loadStripe } from "@stripe/stripe-js";
@@ -15,21 +16,124 @@ export default function Home() {
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-      <InlineLoader />
-    </div>
+      <div className="flex flex-1 items-center justify-center">
+        <InlineLoader />
+      </div>
     );
   }
 
   if (!session) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <h1 className="text-lg font-medium text-gray-700">
+      <div className="flex min-h-screen items-center justify-center bg-[#F7F7F7] px-6 text-center">
+        <h1 className="text-base font-medium text-[#717173]">
           Please log in to continue
         </h1>
       </div>
     );
   }
+
+  const months = useMemo(() => {
+    const now = new Date();
+    const base = new Date(now.getFullYear(), 0, 1);
+    return Array.from({ length: 12 }, (_, index) => {
+      const current = new Date(base);
+      current.setMonth(index);
+      return {
+        label: current.toLocaleString("en-US", { month: "long" }),
+        value: index,
+      };
+    });
+  }, []);
+
+  const activeMonth = new Date().getMonth();
+
+  const ledgerGroups = useMemo(() => {
+    if (!userInfo?.ledger || userInfo.ledger.length === 0) {
+      return [];
+    }
+
+    const groups: Record<string, { entries: any[] } & { date: Date }> = {};
+
+    userInfo.ledger.forEach((entry: any) => {
+      const timestamp = (entry.ts ?? 0) * 1000;
+      const date = timestamp ? new Date(timestamp) : new Date();
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+        2,
+        "0"
+      )}-${String(date.getDate()).padStart(2, "0")}`;
+
+      if (!groups[key]) {
+        groups[key] = { date, entries: [] };
+      }
+
+      groups[key].entries.push(entry);
+    });
+
+    const sortedKeys = Object.keys(groups).sort(
+      (a, b) => new Date(b).getTime() - new Date(a).getTime()
+    );
+
+    return sortedKeys.map((key) => {
+      const value = groups[key];
+      const entries = [...value.entries].sort(
+        (a, b) => (b.ts ?? 0) - (a.ts ?? 0)
+      );
+
+      return {
+        key,
+        date: value.date,
+        entries,
+      };
+    });
+  }, [userInfo?.ledger]);
+
+  const plan = userInfo?.user?.plan_type ?? "No plan";
+  const statusRaw = userInfo?.user?.subscription_status ?? "inactive";
+  const statusLabel = statusRaw.replace(/_/g, " ");
+  const statusDisplay = statusLabel.replace(/\b\w/g, (char) => char.toUpperCase());
+  const statusBadgeClass =
+    statusRaw.toLowerCase() === "active"
+      ? "bg-[#4F55F1]/10 text-[#4F55F1]"
+      : "bg-[#E2E2E7] text-[#717173]";
+  const creditsRemaining = userInfo?.credits_remaining ?? 0;
+  const renewalDate = userInfo?.user?.renewal_date
+    ? new Intl.DateTimeFormat("en-US", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      }).format(new Date(userInfo.user.renewal_date * 1000))
+    : "N/A";
+
+  const dayFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-US", {
+        day: "numeric",
+        month: "long",
+      }),
+    []
+  );
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    []
+  );
+
+  const formatDayHeading = (date: Date) => dayFormatter.format(date);
+
+  const formatTime = (timestamp?: number) => {
+    if (!timestamp) {
+      return "Pending";
+    }
+
+    return timeFormatter.format(new Date(timestamp * 1000));
+  };
+
+  const formatAmount = (value: number) =>
+    `${value > 0 ? "+" : ""}${value} credits`;
 
   const handleBuyCredits = async () => {
     try {
@@ -65,93 +169,173 @@ export default function Home() {
   };
 
   return (
-    <div className="max-w-4xl mx-auto px-6 py-10 space-y-10">
-      {/* Welcome */}
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
-          Welcome to AuthorityPoint
-        </h1>
-        <p className="text-gray-600">Hello, {session.user.email}</p>
-      </div>
-
-      {/* Account Overview */}
-      {userInfo && (
-        <section className="bg-white rounded-2xl shadow-sm border p-6 space-y-6">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">
-              Account Overview
-            </h2>
-            <div className="grid grid-cols-2 gap-y-3 text-sm text-gray-700">
-              <p>
-                <span className="font-medium">Plan:</span>{" "}
-                {userInfo?.user && userInfo.user.plan_type
-                  ? userInfo.user.plan_type
-                  : "No plan"}
-              </p>
-              <p>
-                <span className="font-medium">Status:</span>{" "}
-                {userInfo?.user && userInfo.user.subscription_status
-                  ? userInfo.user.subscription_status
-                  : "inactive"}
-              </p>
-              <p>
-                <span className="font-medium">Credits Remaining:</span>{" "}
-                {userInfo?.credits_remaining ?? 0}
-              </p>
-              <p>
-                <span className="font-medium">Renewal Date:</span>{" "}
-                {userInfo?.user && userInfo.user.renewal_date
-                  ? new Date(
-                      userInfo.user.renewal_date * 1000
-                    ).toLocaleDateString()
-                  : "N/A"}
+    <div className="flex flex-col gap-10 text-[#111827]">
+      <header className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-[0.32em] text-[#717173]">
+              Overview
+            </p>
+            <div>
+              <h1 className="text-4xl font-semibold leading-tight text-[#111827]">
+                Transactions
+              </h1>
+              <p className="text-sm text-[#717173]">
+                Hello, {session.user.email}
               </p>
             </div>
+          </div>
+          {(userInfo?.credits_remaining ?? 0) <= 0 && (
+            <button
+              onClick={handleBuyCredits}
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-[#4F55F1] px-6 py-3 text-sm font-semibold text-white shadow-[0_14px_24px_rgba(79,85,241,0.32)] transition-all duration-150 hover:translate-y-[-1px] hover:shadow-[0_16px_30px_rgba(79,85,241,0.4)] active:translate-y-[1px]"
+            >
+              <CreditCard className="h-4 w-4" />
+              Buy +1000 Credits ($10)
+            </button>
+          )}
+        </div>
 
-            {/* Buy Credits */}
-            {(userInfo?.credits_remaining ?? 0) <= 0 && (
-              <div className="mt-6">
-                <button
-                  onClick={handleBuyCredits}
-                  className="flex items-center justify-center gap-2 px-6 py-3 w-full sm:w-auto rounded-full bg-gradient-to-b from-gray-100 to-gray-800 text-white font-medium shadow-sm hover:scale-[1.02] active:scale-[0.98] transition-transform"
-                >
-                  <CreditCard className="w-4 h-4" />
-                  Buy +1000 Credits ($10)
-                </button>
+        <div className="-mx-2 flex gap-2 overflow-x-auto pb-1">
+          {months.map((month) => (
+            <button
+              key={month.value}
+              className={`shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                month.value === activeMonth
+                  ? "bg-[#4F55F1] text-white shadow-[0_10px_20px_rgba(79,85,241,0.25)]"
+                  : "bg-transparent text-[#717173] hover:bg-[#E2E2E7]"
+              }`}
+              type="button"
+            >
+              {month.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {userInfo && (
+        <section className="rounded-[32px] border border-[#E2E2E7] bg-white p-8 shadow-[0_32px_60px_rgba(15,23,42,0.06)]">
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-3">
+              <p className="text-xs font-medium uppercase tracking-[0.28em] text-[#717173]">
+                Active plan
+              </p>
+              <div>
+                <h2 className="text-2xl font-semibold text-[#111827]">
+                  {plan}
+                </h2>
+                <p className="text-sm text-[#717173]">
+                  {session.user.email}
+                </p>
               </div>
-            )}
+            </div>
+            <span
+              className={`inline-flex items-center rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] ${statusBadgeClass}`}
+            >
+              {statusDisplay.toUpperCase()}
+            </span>
           </div>
 
-          {/* Transactions */}
-          <div>
-            <h3 className="text-md font-semibold text-gray-900 mb-3">
-              Recent Transactions
-            </h3>
-            <div className="space-y-2">
-              {userInfo?.ledger && userInfo.ledger.length > 0 ? (
-                userInfo.ledger.map((entry: any, idx: number) => (
-                  <div
-                    key={idx}
-                    className="flex justify-between items-center text-sm text-gray-700 border-b last:border-0 py-2"
-                  >
-                    <span>
-                      {entry.change > 0 ? "+" : ""}
-                      {entry.change} credits — {entry.reason}
-                    </span>
-                    <span className="text-gray-500 text-xs">
-                      {new Date(entry.ts * 1000).toLocaleString()}
-                    </span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">
-                  No recent transactions
-                </p>
-              )}
+          <div className="mt-10 grid gap-8 sm:grid-cols-3">
+            <div>
+              <p className="text-sm font-medium text-[#717173]">
+                Credits remaining
+              </p>
+              <p className="mt-3 text-4xl font-semibold tracking-tight text-[#111827]">
+                {creditsRemaining}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-[#717173]">
+                Renewal date
+              </p>
+              <p className="mt-3 text-lg font-medium text-[#111827]">
+                {renewalDate}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-[#717173]">
+                Plan status
+              </p>
+              <p className="mt-3 text-lg font-medium text-[#111827]">
+                {statusDisplay}
+              </p>
             </div>
           </div>
         </section>
       )}
+
+      <section className="rounded-[32px] border border-[#E2E2E7] bg-white p-6 sm:p-8 shadow-[0_28px_60px_rgba(15,23,42,0.05)]">
+        <div className="mb-6 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-[#111827]">
+            Recent transactions
+          </h3>
+          <span className="text-xs font-medium uppercase tracking-[0.24em] text-[#717173]">
+            Ledger
+          </span>
+        </div>
+
+        {ledgerGroups.length > 0 ? (
+          <div className="space-y-10">
+            {ledgerGroups.map((group) => (
+              <div key={group.key} className="space-y-4">
+                <div className="flex items-center gap-3">
+                  <span className="text-xs font-semibold uppercase tracking-[0.28em] text-[#717173]">
+                    {formatDayHeading(group.date)}
+                  </span>
+                  <span className="h-px flex-1 bg-[#E2E2E7]" />
+                </div>
+                <div className="space-y-2">
+                  {group.entries.map((entry: any, idx: number) => (
+                    <div
+                      key={`${group.key}-${idx}`}
+                      className="flex items-center justify-between rounded-2xl px-4 py-4 transition-colors duration-150 hover:bg-[#F7F7F7]"
+                    >
+                      <div className="flex items-center gap-4">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#F7F7F7] text-base font-semibold text-[#4F55F1]">
+                          {entry.change > 0 ? "CR" : "DR"}
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-base font-medium text-[#111827]">
+                            {entry.reason}
+                          </p>
+                          <div className="flex items-center gap-3 text-sm text-[#717173]">
+                            <span>{formatTime(entry.ts)}</span>
+                            <span className="inline-flex items-center rounded-full bg-[#E2E2E7] px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-[#717173]">
+                              {entry.change > 0 ? "Completed" : "Debited"}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <p
+                          className={`text-lg font-semibold ${
+                            entry.change > 0 ? "text-[#111827]" : "text-[#717173]"
+                          }`}
+                        >
+                          {formatAmount(entry.change)}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-[#E2E2E7] bg-[#F7F7F7]/40 px-6 py-16 text-center">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-[0_10px_30px_rgba(15,23,42,0.12)]">
+              <span className="text-sm font-semibold text-[#4F55F1]">AP</span>
+            </div>
+            <h4 className="text-lg font-semibold text-[#111827]">
+              No recent transactions
+            </h4>
+            <p className="mt-2 max-w-xs text-sm text-[#717173]">
+              New credits and debits will appear here in a clean, Revolut-style ledger as soon as they happen.
+            </p>
+          </div>
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the authenticated shell with Revolut-like spacing, borders, and shadows
- overhaul the home dashboard to include Revolut-inspired header, account summary, and ledger grouping

## Testing
- not run (Supabase environment variables required)


------
https://chatgpt.com/codex/tasks/task_e_68e3094cb6bc83289c614fdf7a22d79b