### PR TITLE
Allow jobs page to bypass shared card wrapper

### DIFF
--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -7,8 +7,13 @@ import { useEffect, useState } from "react";
 import AuthorityPointLoader from "../components/AuthorityPointLoader";
 import InlineLoader from "@/components/InlineLoader";
 
+type AugmentedComponent = AppProps["Component"] & {
+  disableWhiteCard?: boolean;
+  backgroundClassName?: string;
+};
+
 interface LayoutProps {
-  Component: AppProps["Component"];
+  Component: AugmentedComponent;
   pageProps: AppProps["pageProps"];
 }
 
@@ -44,19 +49,38 @@ function Layout({ Component, pageProps }: LayoutProps) {
       <AuthorityPointLoader />
     );
   }
+  const backgroundClassName = Component.backgroundClassName ?? "bg-[#F7F7F7]";
+  const disableWhiteCard = Component.disableWhiteCard ?? false;
 
+  const renderPage = () => {
+    if (pageLoading) {
+      return (
+        <div className="flex flex-1 items-center justify-center px-6 py-8 sm:px-8 lg:px-10">
+          <InlineLoader />
+        </div>
+      );
+    }
+
+    return <Component {...pageProps} />;
+  };
 
   return (
-    <div className="min-h-screen flex bg-[#F7F7F7]">
+    <div className={`min-h-screen flex ${backgroundClassName}`}>
       {session && <Navbar />}
       <main
         className={`flex-1 flex flex-col transition-all duration-200 ${session ? "mt-16 px-0 pb-10" : ""
           }`}
       >
-<div className="flex min-h-0 flex-1 flex-col overflow-hidden 
-                rounded-[32px] bg-white shadow-sm 
-                ml-0 lg:ml-[108px] mr-4">
-          {pageLoading ? (
+        <div
+          className={`flex min-h-0 flex-1 flex-col ${
+            disableWhiteCard
+              ? "overflow-visible ml-0 mr-0 lg:ml-[108px]"
+              : "overflow-hidden rounded-[32px] bg-white shadow-sm ml-0 mr-4 lg:ml-[108px]"
+            }`}
+        >
+          {disableWhiteCard ? (
+            renderPage()
+          ) : pageLoading ? (
             <div className="flex flex-1 items-center justify-center px-6 py-8 sm:px-8 lg:px-10">
               <InlineLoader />
             </div>
@@ -74,7 +98,11 @@ function Layout({ Component, pageProps }: LayoutProps) {
 
 }
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+interface MyAppProps extends AppProps {
+  Component: AugmentedComponent;
+}
+
+export default function MyApp({ Component, pageProps }: MyAppProps) {
   return (
     <AuthProvider>
       <Layout Component={Component} pageProps={pageProps} />

--- a/outreach-frontend/pages/jobs/index.tsx
+++ b/outreach-frontend/pages/jobs/index.tsx
@@ -194,7 +194,7 @@ function ProgressBar({ value }: { value: number }) {
   );
 }
 
-export default function JobsPage() {
+function JobsPage() {
   const router = useRouter();
   const { session } = useAuth();
 
@@ -577,7 +577,7 @@ export default function JobsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[#F5F6FB]">
+    <div className="min-h-screen bg-gradient-to-br from-[#F7F8FC] via-[#EEF1FA] to-[#E6E9F5]">
       <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-12 md:px-8">
         <div
           className={`transition-all duration-300 ${
@@ -935,3 +935,14 @@ function DetailRow({ icon, label, value }: { icon: ReactNode; label: string; val
     </div>
   );
 }
+
+const JobsPageWithLayout = JobsPage as typeof JobsPage & {
+  disableWhiteCard?: boolean;
+  backgroundClassName?: string;
+};
+
+JobsPageWithLayout.disableWhiteCard = true;
+JobsPageWithLayout.backgroundClassName =
+  "bg-gradient-to-br from-[#F7F8FC] via-[#EEF1FA] to-[#E6E9F5]";
+
+export default JobsPageWithLayout;


### PR DESCRIPTION
## Summary
- extend the global app layout to let individual pages disable the white card wrapper and override the background
- update the jobs timeline to opt out of the shared card, reuse the Revolut-inspired gradient, and keep existing loading handling consistent

## Testing
- npm run lint *(fails: ESLint config "next/typescript" is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e32450ceec832884c23be020debda8