### PR TITLE
Fix Streamlit entrypoint init call

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import create_new, past_files
 st.set_page_config(page_title="Personalized Outreach Tool", layout="wide")
 
 # ---------- Init ----------
-init_db()
+db.init_db()
 
 # TEMP: hardcode current user until Next.js login is integrated
 current_user_id = "dev-user-123"


### PR DESCRIPTION
## Summary
- call the database initializer through the imported db module so the Streamlit app boots correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e42a0093c0832881d25eb5f535fdac