### PR TITLE
Restore legacy helpers for Streamlit create flow

### DIFF
--- a/backend/app/gpt_helpers.py
+++ b/backend/app/gpt_helpers.py
@@ -2,6 +2,13 @@ import os
 from openai import OpenAI
 import json
 
+
+def _coalesce_text(value):
+    """Return a stripped string representation for prompt fields."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
 # --- Client (DeepSeek API not OpenAI API) ---
 client = OpenAI(
     api_key=os.getenv("DEEPSEEK_API_KEY"),  # Use your DeepSeek key
@@ -76,3 +83,25 @@ def generate_opener(company, description, industry, role, size, service):
         opener = "[No opener generated]"
     usage = resp.usage
     return opener, usage.prompt_tokens, usage.completion_tokens, usage.total_tokens
+
+
+def generate_line(title, company, description, offer, persona, channel, max_words):
+    """Compatibility wrapper for legacy callers expecting generate_line."""
+    service_context = (
+        f"Offer: {_coalesce_text(offer)}\n"
+        f"Persona: {_coalesce_text(persona)}\n"
+        f"Channel: {_coalesce_text(channel)}\n"
+        f"Max words: {max_words}\n"
+        f"Title: {_coalesce_text(title)}"
+    )
+
+    opener, *_ = generate_opener(
+        _coalesce_text(company),
+        _coalesce_text(description),
+        "",  # industry (unused in legacy preview context)
+        _coalesce_text(title),
+        "",
+        service_context,
+    )
+
+    return opener

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -26,6 +26,16 @@ redis_conn = redis.Redis(host="redis", port=6379, decode_responses=False)
 queue = rq.Queue("default", connection=redis_conn)
 
 
+class _RQExecutor:
+    """Minimal executor interface for legacy Streamlit UI."""
+
+    def submit(self, func, *args, **kwargs):
+        return queue.enqueue(func, *args, **kwargs)
+
+
+EXEC = _RQExecutor()
+
+
 RAW_CHUNK_BASE_DIR = "/data/raw_chunks"
 RAW_CHUNK_BUCKET = "inputs"
 


### PR DESCRIPTION
## Summary
- add a lightweight RQ executor proxy so the Streamlit UI can submit jobs without import errors
- reintroduce a generate_line helper that wraps the new generate_opener implementation for previews

## Testing
- python -m compileall backend/app/gpt_helpers.py backend/app/jobs.py create_new.py

------
https://chatgpt.com/codex/tasks/task_e_68e42c4592a88328bce815723e663320