### PR TITLE
Reserve credits when creating jobs

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -356,7 +356,7 @@ def _deduct_job_credits(
         print(
             f"[Credits] Job {job_id} already has credits deducted; skipping new deduction"
         )
-        return False
+        return True
 
     deducted = False
     previous_balance = 0

--- a/backend/app/tests/test_job_dispatch.py
+++ b/backend/app/tests/test_job_dispatch.py
@@ -250,3 +250,25 @@ def test_process_job_only_one_worker_claims(monkeypatch):
     assert fake_supabase.profiles[fake_supabase.user_id]["credits_remaining"] == 9
     assert fake_supabase.jobs[fake_supabase.job_id]["status"] == "in_progress"
     assert fake_supabase.jobs[fake_supabase.job_id]["meta_json"].get("credits_deducted") is True
+
+
+def test_deduct_job_credits_noop_when_already_deducted():
+    fake_supabase = FakeSupabase()
+    job_id = fake_supabase.job_id
+    meta = {
+        "credits_deducted": True,
+        "credit_cost": 2,
+    }
+
+    result = jobs._deduct_job_credits(
+        job_id,
+        fake_supabase.user_id,
+        2,
+        meta,
+        supabase_client=fake_supabase,
+    )
+
+    assert result is True
+    assert fake_supabase.ledger_entries == []
+    assert fake_supabase.profiles[fake_supabase.user_id]["credits_remaining"] == 10
+    assert meta["credits_deducted"] is True


### PR DESCRIPTION
## Summary
- acquire a per-user Redis lock during job creation and deduct credits immediately to prevent race conditions
- return early with insufficient credit errors when reservation fails and handle deduction errors consistently
- expand the XLSX endpoint tests with richer Supabase/Redis fakes and assertions that credits and ledger entries are updated
- allow workers to reuse pre-reserved credits so successful jobs advance to completion and add a regression test for the credit check helper

## Testing
- pytest backend/app/tests/test_xlsx_endpoints.py -q
- pytest backend/app/tests/test_job_dispatch.py::test_deduct_job_credits_noop_when_already_deducted -q

------
https://chatgpt.com/codex/tasks/task_e_68e4336de3e88328bca85e9b20da9fcc