### PR TITLE
Prevent layout spinner on shallow job navigations

### DIFF
--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -23,7 +23,11 @@ function Layout({ Component, pageProps }: LayoutProps) {
   const [pageLoading, setPageLoading] = useState(false);
 
   useEffect(() => {
-    const handleStart = () => setPageLoading(true);
+    const handleStart = (_url: string, { shallow } = { shallow: false }) => {
+      if (!shallow) {
+        setPageLoading(true);
+      }
+    };
     const handleComplete = () => setPageLoading(false);
 
     router.events.on("routeChangeStart", handleStart);


### PR DESCRIPTION
## Summary
- avoid triggering the global page loader when a shallow route change occurs so the jobs drawer opens without a full refresh

## Testing
- npm run lint *(fails: Missing script "lint" in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e6ad69348328b01a1b3f3bb40184