### PR TITLE
Handle same-page navigations without layout reload

### DIFF
--- a/outreach-frontend/pages/_app.tsx
+++ b/outreach-frontend/pages/_app.tsx
@@ -23,7 +23,26 @@ function Layout({ Component, pageProps }: LayoutProps) {
   const [pageLoading, setPageLoading] = useState(false);
 
   useEffect(() => {
-    const handleStart = () => setPageLoading(true);
+    const handleStart = (url: string, { shallow } = { shallow: false }) => {
+      if (shallow) {
+        return;
+      }
+
+      if (typeof window !== "undefined") {
+        try {
+          const nextUrl = new URL(url, window.location.href);
+          const currentUrl = new URL(router.asPath, window.location.href);
+
+          if (nextUrl.pathname === currentUrl.pathname) {
+            return;
+          }
+        } catch {
+          // ignore malformed URLs and fall back to showing the loader
+        }
+      }
+
+      setPageLoading(true);
+    };
     const handleComplete = () => setPageLoading(false);
 
     router.events.on("routeChangeStart", handleStart);


### PR DESCRIPTION
## Summary
- treat shallow navigations and same-path route changes as inline updates that should not trigger the global loader
- ensure closing the jobs detail drawer no longer flashes the full-page loading screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e6ad69348328b01a1b3f3bb40184